### PR TITLE
Add lifecycle experimental badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # pacta.r.package <img src="man/figures/logo.png" align="right" width="120" />
 
-  <!-- badges: start -->
-  [![Codecov test coverage](https://codecov.io/gh/RMI-PACTA/pacta.r.package/branch/main/graph/badge.svg)](https://app.codecov.io/gh/RMI-PACTA/pacta.r.package?branch=main)
-  [![R-CMD-check](https://github.com/RMI-PACTA/pacta.r.package/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/RMI-PACTA/pacta.r.package/actions/workflows/R-CMD-check.yaml)
-  <!-- badges: end -->
+<!-- badges: start -->
+[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+[![Codecov test coverage](https://codecov.io/gh/RMI-PACTA/pacta.r.package/branch/main/graph/badge.svg)](https://app.codecov.io/gh/RMI-PACTA/pacta.r.package?branch=main)
+[![R-CMD-check](https://github.com/RMI-PACTA/pacta.r.package/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/RMI-PACTA/pacta.r.package/actions/workflows/R-CMD-check.yaml)
+<!-- badges: end -->
 
 The goal of `pacta.r.package` is to provide a default template R package 
 template. This template can be used to easily scaffold new PACTA R packages. 


### PR DESCRIPTION
I chose `experimental` as a default. This way all future R packages based on this template will default to `experimental` and only be bumped to a more stable stage intentionally. 