### PR TITLE
Add installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,18 @@
 
 The goal of `pacta.r.package` is to provide a default template R package 
 template. This template can be used to easily scaffold new PACTA R packages. 
+
+## Installation
+
+Install the released version of `pacta.r.package` from CRAN with:
+
+``` r
+install.packages("pacta.r.package")
+```
+
+Or install the development version of `pacta.r.package` with something like this:
+
+``` r
+# install.packages("pak")
+pak::pak("RMI-PACTA/pacta.r.package")
+```


### PR DESCRIPTION
I think it makes sense to have these in the template (at a minimum, it ensures that any future packages based on the template call `pak` so we don't have to do sweeps for `devtools`)

See: https://github.com/RMI-PACTA/r2dii.data/pull/323