### PR TITLE
Add pkgdown structure based on rmi-template

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,6 @@
 ^codecov\.yml$
 ^\.github$
 ^LICENSE\.md$
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 .Ruserdata
+docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,3 +17,4 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Suggests: 
     covr
+Config/Needs/website: rmi-pacta/pacta.pkgdown.rmitemplate

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,3 @@
+url: https://rmi-pacta.github.io/pacta.r.package
+template:
+  package: pacta.pkgdown.rmitemplate


### PR DESCRIPTION
Note: this package seems to already have the `pkgdown` GH action: https://github.com/RMI-PACTA/pacta.r.package/blob/main/.github/workflows/pkgdown.yaml

Closes #12 